### PR TITLE
Display geodetic coordinates

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
             <div id="time-display">
                 <span id="simulationTime">00分00秒</span>
             </div>
+            <div id="geodetic-display">緯度: 0.0000° 経度: 0.0000° 高度: 0.0 km</div>
         </div>
         
         <div id="controls">

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,6 +106,7 @@ class HillEquationSimulation implements EventHandlerCallbacks {
         
         // UI表示を更新
         this.uiControls.updateOrbitInfo(this.currentOrbitElements, eciData?.position, eciData?.geodetic);
+        this.uiControls.updateGeodeticDisplay(eciData?.geodetic);
     }
     
     
@@ -281,9 +282,10 @@ class HillEquationSimulation implements EventHandlerCallbacks {
         // 現在時刻でECI座標と緯度経度高度を計算
         const currentDate = new Date(Date.now() + this.time * 1000);
         const eciData = OrbitElementsCalculator.getECIPosition(this.currentOrbitElements, currentDate);
-        
+
         // UIの軌道情報エリアを更新
         this.uiControls.updateOrbitInfo(this.currentOrbitElements, eciData?.position, eciData?.geodetic);
+        this.uiControls.updateGeodeticDisplay(eciData?.geodetic);
     }
     
     // この機能はRenderingSystemに移譲済みのため削除
@@ -466,7 +468,8 @@ class HillEquationSimulation implements EventHandlerCallbacks {
         
         // UI表示を更新
         this.uiControls.updateOrbitInfo(this.currentOrbitElements, eciData?.position, eciData?.geodetic);
-        
+        this.uiControls.updateGeodeticDisplay(eciData?.geodetic);
+
         // 軌道パラメータを更新
         this.updateOrbitParameters();
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -300,6 +300,19 @@ button:active {
     text-shadow: 0 0 10px rgba(74, 158, 255, 0.5);
 }
 
+#geodetic-display {
+    position: absolute;
+    top: 60px;
+    left: 20px;
+    padding: 8px 12px;
+    background: rgba(0, 0, 0, 0.6);
+    border-radius: 8px;
+    font-size: 12px;
+    color: #ffffff;
+    border: 1px solid rgba(74, 158, 255, 0.3);
+    z-index: 15;
+}
+
 #selectedSatelliteInfo {
     position: absolute;
     top: 70px;
@@ -364,7 +377,14 @@ button:active {
         padding: 8px 12px;
         font-size: 14px;
     }
-    
+
+    #geodetic-display {
+        top: 40px;
+        left: 10px;
+        padding: 6px 10px;
+        font-size: 11px;
+    }
+
     #selectedSatelliteInfo {
         top: 50px;
         left: 10px;

--- a/src/ui/UIControls.ts
+++ b/src/ui/UIControls.ts
@@ -21,6 +21,7 @@ export interface UIControlElements {
     argOfPerigee: HTMLInputElement;
     meanAnomaly: HTMLInputElement;
     orbitInfo: HTMLDivElement;
+    geodeticDisplay: HTMLDivElement;
 }
 
 export class UIControls {
@@ -49,7 +50,8 @@ export class UIControls {
             eccentricity: document.getElementById('eccentricity') as HTMLInputElement,
             argOfPerigee: document.getElementById('argOfPerigee') as HTMLInputElement,
             meanAnomaly: document.getElementById('meanAnomaly') as HTMLInputElement,
-            orbitInfo: document.getElementById('orbitInfo') as HTMLDivElement
+            orbitInfo: document.getElementById('orbitInfo') as HTMLDivElement,
+            geodeticDisplay: document.getElementById('geodetic-display') as HTMLDivElement
         };
     }
     
@@ -126,6 +128,15 @@ export class UIControls {
                 ${geodeticInfo}
             </div>
         `;
+    }
+
+    updateGeodeticDisplay(geodetic?: { latitude: number; longitude: number; altitude: number } | null): void {
+        if (!geodetic) {
+            this.elements.geodeticDisplay.textContent = '';
+            return;
+        }
+        this.elements.geodeticDisplay.textContent =
+            `緯度: ${geodetic.latitude.toFixed(4)}°  経度: ${geodetic.longitude.toFixed(4)}°  高度: ${geodetic.altitude.toFixed(1)} km`;
     }
     
     setupPlacementPatternLimits(): void {


### PR DESCRIPTION
## Summary
- show a geodetic overlay below the simulation time
- style the new overlay for desktop and mobile
- wire up UIControls to update the overlay
- update simulation logic to refresh geodetic info

## Testing
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_684620f2f33c832894458b9bbac1c316