### PR TITLE
Fix Earth orientation mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,17 @@ z̈ + n²z = 0          (Cross-track方向)
 
 ### 座標系
 
+
 LVLH座標系（Local Vertical Local Horizontal）を使用：
 
-- **X軸（赤）**: Radial（径方向） - 地心からターゲット衛星に向かう方向（外向き正）
-- **Y軸（緑）**: Along-track（軌道進行方向） - ターゲット衛星の速度ベクトル方向
-- **Z軸（青）**: Cross-track（軌道面垂直方向） - 軌道角運動量ベクトル方向
+- **X軸（青）**: Cross-track（軌道面垂直方向）
+- **Y軸（赤）**: Radial（径方向） - 地心からターゲット衛星に向かう方向
+- **Z軸（緑）**: Along-track（軌道進行方向）
 
-**重要**: Three.jsの表示では物理座標系から以下の変換を適用：
-- x_display = x_physics
-- y_display = z_physics  
-- z_display = -y_physics
+**重要**: Three.js表示での軸対応：
+- x_display = W (Cross-track)
+- y_display = R (Radial)
+- z_display = S (Along-track)
 
 ## 🏗️ プロジェクト構成
 

--- a/index.html
+++ b/index.html
@@ -21,9 +21,9 @@
         <div id="canvas-container">
             <canvas id="canvas"></canvas>
             <div id="axes-info">
-                <div class="axis-label" style="color: #ff6b6b">X軸: Radial (径方向 - 地心→衛星)</div>
-                <div class="axis-label" style="color: #2ECC71">Y軸: Along-track (軌道進行方向)</div>
-                <div class="axis-label" style="color: #00BFFF">Z軸: Cross-track (軌道面垂直方向)</div>
+                <div class="axis-label" style="color: #00BFFF">X軸: Cross-track (軌道面垂直方向)</div>
+                <div class="axis-label" style="color: #ff6b6b">Y軸: Radial (径方向 - 地心→衛星)</div>
+                <div class="axis-label" style="color: #2ECC71">Z軸: Along-track (軌道進行方向)</div>
                 <div class="axis-note">※表示はThree.js座標系に変換済み</div>
             </div>
             <div id="time-display">

--- a/src/simulation/FrameTransforms.ts
+++ b/src/simulation/FrameTransforms.ts
@@ -49,14 +49,19 @@ export namespace FrameTransforms {
     }
 
     /**
-     * Constant transform from RSW (physics) to Three.js coordinates.
-     * RSW axes:  +R (inward), +S (along-track), +W (cross-track)
-     * Three.js:  +X (right), +Y (up), +Z (out of screen)
-     */
+    * Constant transform from RSW (physics) to Three.js coordinates.
+    * RSW axes:  +R (radial outward), +S (along-track), +W (cross-track)
+    * Three.js:  +X (right), +Y (up), +Z (out of screen)
+    *
+    * Mapping used here:
+    *   X_three = W
+    *   Y_three = R
+    *   Z_three = S
+    */
     export const rswToThree = new THREE.Matrix4().set(
         /* row 1 */ 0, 0, 1, 0,   // W -> +X
-        /* row 2 */-1, 0, 0, 0,   // R -> -Y
-        /* row 3 */ 0,-1, 0, 0,   // S -> -Z
+        /* row 2 */ 1, 0, 0, 0,   // R -> +Y
+        /* row 3 */ 0, 1, 0, 0,   // S -> +Z
         /* row 4 */ 0, 0, 0, 1
     );
 }


### PR DESCRIPTION
## Summary
- correct RSW→Three.js transform to avoid flipped Earth
- adjust axis descriptions in the viewer
- update README with new mapping

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6846f5c7d1008328b76d96956f907cbc