### PR TITLE
Fix touch zoom behavior on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="color-scheme" content="dark light">
     <title>Relative motion equations simulator</title>
     <link rel="stylesheet" href="/src/styles.css">

--- a/src/interaction/CameraController.ts
+++ b/src/interaction/CameraController.ts
@@ -32,6 +32,7 @@ export class CameraController {
         });
 
         this.container.addEventListener('touchstart', (e) => {
+            e.preventDefault();
             if (e.touches.length === 1) {
                 this.mouseDown = true;
                 this.mouseX = e.touches[0].clientX;
@@ -41,7 +42,7 @@ export class CameraController {
                 this.pinchStartDistance = this.getTouchDistance(e.touches[0], e.touches[1]);
                 this.initialCameraDistance = this.cameraDistance;
             }
-        });
+        }, { passive: false });
 
         this.container.addEventListener('mousemove', (e) => {
             if (this.mouseDown) {
@@ -55,6 +56,7 @@ export class CameraController {
         });
 
         this.container.addEventListener('touchmove', (e) => {
+            e.preventDefault();
             if (e.touches.length === 1 && this.mouseDown) {
                 const deltaX = e.touches[0].clientX - this.mouseX;
                 const deltaY = e.touches[0].clientY - this.mouseY;
@@ -74,10 +76,11 @@ export class CameraController {
             this.mouseDown = false;
         });
 
-        this.container.addEventListener('touchend', () => {
+        this.container.addEventListener('touchend', (e) => {
+            e.preventDefault();
             this.mouseDown = false;
             this.pinchStartDistance = null;
-        });
+        }, { passive: false });
 
         this.container.addEventListener('wheel', (e) => {
             this.cameraDistance *= (1 + e.deltaY * 0.001);

--- a/src/styles.css
+++ b/src/styles.css
@@ -9,7 +9,7 @@ body {
 
 #container {
     width: 100vw;
-    height: 100vh;
+    height: 100dvh;
     position: relative;
     display: flex;
     flex-direction: column;
@@ -32,9 +32,16 @@ h1 {
 #canvas-container {
     position: relative;
     width: 100%;
-    height: 100vh;
+    height: 100dvh;
     background: radial-gradient(ellipse at center, #0a0a0f 0%, #000000 100%);
     overflow: hidden;
+    touch-action: none;
+}
+
+#canvas {
+    width: 100%;
+    height: 100%;
+    touch-action: none;
 }
 
 
@@ -480,7 +487,7 @@ button:active {
     top: 0;
     left: -400px;
     width: 380px;
-    height: 100vh;
+    height: 100dvh;
     background: linear-gradient(180deg, rgba(15, 15, 20, 0.98) 0%, rgba(25, 25, 35, 0.95) 100%);
     border-right: 1px solid rgba(255, 140, 70, 0.25);
     transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -1290,7 +1297,7 @@ button:active {
     top: 0;
     left: -400px;
     width: 380px;
-    height: 100vh;
+    height: 100dvh;
     background: linear-gradient(180deg, rgba(15, 15, 20, 0.98) 0%, rgba(25, 25, 35, 0.95) 100%);
     border-right: 1px solid rgba(255, 140, 70, 0.25);
     transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
## Summary
- disable browser zooming and only zoom 3D canvas on pinch
- use dynamic viewport units so mobile browser UI isn't hidden
- prevent default pinch events in camera controller

## Testing
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6847fb4913cc8328bd7f6c7d7e6608e1